### PR TITLE
Chat: prevent appendStream from reverting artifact finalization

### DIFF
--- a/dhxpyt/__init__.py
+++ b/dhxpyt/__init__.py
@@ -3,7 +3,7 @@
 """
 
 __widgetset__ = "dhxpyt"
-__version__ = "0.9.13"
+__version__ = "0.9.14"
 __version_tuple__ = tuple(map(int, __version__.split('.')))
 __description__ = "Python wrapper for DHTMLX widgets"
 

--- a/dhxpyt/dhxsrc/chat.js
+++ b/dhxpyt/dhxsrc/chat.js
@@ -2143,7 +2143,7 @@
                     const result = this._processStreamingText(displayText, { messageId: message.id });
                     displayText = result.processedText;
                     artifacts = result.artifacts;
-                    if (result.hasIncompleteArtifact && message.streaming) {
+                    if (result.hasIncompleteArtifact && (message.streaming || message.meta?.cancelled)) {
                         message.meta = message.meta || {};
                         if (!message.meta.artifactBuilding) {
                             message.meta.artifactBuildingButton = true;
@@ -2671,7 +2671,8 @@
             record.message.streaming = true;
             if (this.options.enableArtifacts) {
                 record.message.meta = record.message.meta || {};
-                if (!record.message.meta.artifactBuilding && !record.message.meta.artifactBuildingButton) {
+                // Don't set building flags if artifact has already been finalized
+                if (!record.message.meta.artifactBuilding && !record.message.meta.artifactBuildingButton && !record.message.meta.artifactFinalized) {
                     const text = record.message.content || "";
                     const hasPartialMarker = /:{4}artifact\b|:{4}artifact\{?|:{4}artifact\s|:{4}Artifact\b|:{4}Artifact\s/i.test(text);
                     if (this.shouldRedirectToArtifact(text) || hasPartialMarker) {
@@ -3733,6 +3734,8 @@ def _dhx_run_py_artifact(code_b64: str) -> str:
             message.meta.artifactBuildingContent = null;
             message.meta.artifactBuildingButtonLabel = null;
             message.meta.artifactBuildingLabel = null;
+            // Mark artifact as finalized to prevent appendStream from re-setting the building flags
+            message.meta.artifactFinalized = true;
             if (message.meta.thinkingLabel === "Building…") {
                 message.meta.thinkingLabel = null;
             }

--- a/dhxpyt/dhxsrc/chat.js
+++ b/dhxpyt/dhxsrc/chat.js
@@ -3734,7 +3734,6 @@ def _dhx_run_py_artifact(code_b64: str) -> str:
             message.meta.artifactBuildingContent = null;
             message.meta.artifactBuildingButtonLabel = null;
             message.meta.artifactBuildingLabel = null;
-            // Mark artifact as finalized to prevent appendStream from re-setting the building flags
             message.meta.artifactFinalized = true;
             if (message.meta.thinkingLabel === "Building…") {
                 message.meta.thinkingLabel = null;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dhxpyt"
-version = "0.9.13"
+version = "0.9.14"
 description = "Python wrapper for DHTMLX widgets"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
Resolves a race where appendStream could run after _finalizeStreamingArtifact and re‑set “artifact building” UI state. 

Change marks artifacts as finalized and guard appendStream from re‑applying building flags; renders the “Code” indicator for incomplete artifacts when a stream is cancelled.